### PR TITLE
feat: fall back to TzKT for missing withdrawal L1 amount

### DIFF
--- a/src/stores/networkStore.ts
+++ b/src/stores/networkStore.ts
@@ -8,6 +8,7 @@ export interface NetworkConfig {
   networkName: string;
   etherlinkExplorerUrl: string;
   tezosExplorerUrl: string;
+  tezosExplorerApiUrl: string;
   graphqlEndpoint: string;
 }
 
@@ -17,6 +18,7 @@ const MAINNET_CONFIG: NetworkConfig = {
   networkName: 'Etherlink Mainnet',
   etherlinkExplorerUrl: 'https://explorer.etherlink.com',
   tezosExplorerUrl: 'https://tzkt.io',
+  tezosExplorerApiUrl: 'https://api.tzkt.io',
   graphqlEndpoint: 'https://bridge.indexer.etherlink.com/v1/graphql',
 };
 
@@ -26,6 +28,7 @@ const TESTNET_CONFIG: NetworkConfig = {
   networkName: 'Etherlink Shadownet Testnet',
   etherlinkExplorerUrl: 'https://shadownet.explorer.etherlink.com',
   tezosExplorerUrl: 'https://shadownet.tzkt.io',
+  tezosExplorerApiUrl: 'https://api.shadownet.tzkt.io',
   graphqlEndpoint: 'https://shadownet.bridge.indexer.etherlink.com/v1/graphql',
 };
 

--- a/src/stores/transactionDetailsStore.ts
+++ b/src/stores/transactionDetailsStore.ts
@@ -1,12 +1,17 @@
-import { makeAutoObservable } from "mobx";
+import { makeAutoObservable, runInAction } from "mobx";
 import { TezosTransaction, tezosTransactionStore } from "./tezosTransactionStore";
+import { networkStore } from "./networkStore";
 import { GraphQLResponse } from "@/types/tezosTransaction";
 import { formatDateTime, formatEtherlinkValue } from '@/utils/formatters';
+import { fetchWithdrawalL1ReceivedAmount } from '@/utils/tzktVerification';
 
 export class TransactionDetailsStore {
   selectedTransaction: TezosTransaction | null = null;
   loadingState: 'idle' | 'loading' | 'error' = 'idle';
   error: string | null = null;
+
+  // L1 amount sourced from TzKT when the indexer didn't return one (see recoverMissingL1Amount)
+  recoveredL1Amount: string | null = null;
 
   constructor() {
     makeAutoObservable(this);
@@ -61,12 +66,18 @@ export class TransactionDetailsStore {
     
     const toBlockString = (level?: number) => (level !== undefined && level !== null ? String(level) : undefined);
 
+    // For withdrawals the L1 amount is the value received on Tezos. When the
+    // indexer didn't return one, fall back to the value sourced from TzKT.
+    const l1Amount: string | undefined = isDeposit
+      ? tx.sendingAmount
+      : (this.recoveredL1Amount ?? tx.receivingAmount);
+
     const l1 = {
       network: 'Tezos',
       hash: formatValue(tx.l1TxHash, false),
       address: formatValue(tx.input?.l1_account, false),
       block: toBlockString(tx.l1Block),
-      amount: isDeposit ? tx.sendingAmount : tx.receivingAmount
+      amount: l1Amount
     };
 
     const l2 = {
@@ -119,6 +130,7 @@ export class TransactionDetailsStore {
   async getTransactionDetails(hash: string): Promise<TezosTransaction | null> {
     this.loadingState = 'loading';
     this.error = null;
+    this.recoveredL1Amount = null;
 
     try {
       const operations: GraphQLResponse[] | null = await this.fetchOperationByHash(hash);
@@ -146,6 +158,11 @@ export class TransactionDetailsStore {
 
       this.selectedTransaction = transaction;
       this.loadingState = 'idle';
+
+      // If the indexer didn't return an L1 amount, source it from TzKT in the
+      // background so the page renders immediately and updates reactively.
+      void this.recoverMissingL1Amount(transaction);
+
       return transaction;
 
     } catch (error) {
@@ -154,10 +171,46 @@ export class TransactionDetailsStore {
     }
   }
 
+  // Fallback for when the indexer doesn't return a regular withdrawal's L1
+  // (Tezos) amount: source it from TzKT instead. Only acts when the indexer
+  // amount is missing/zero, so a healthy indexer is never second-guessed.
+  private async recoverMissingL1Amount(tx: TezosTransaction<GraphQLResponse>): Promise<void> {
+    if (tx.type !== 'withdrawal' || !tx.l1TxHash) return;
+
+    // Fast withdrawals carry their L1 amount on a separately-linked payout
+    // record, so they're handled elsewhere and don't need recovery here.
+    if (tx.isFastWithdrawal) return;
+
+    // Indexer already returned an amount -> nothing to do.
+    const indexerRaw: string | undefined = tx.input?.withdrawal?.l1_transaction?.amount;
+    if (indexerRaw && indexerRaw !== '0') return;
+
+    // Native XTZ is always mutez (6 dp); FA tokens use their own decimals.
+    const isNativeXtz: boolean = tx.symbol === 'XTZ';
+    const decimals: number = isNativeXtz
+      ? 6
+      : (tx.input?.withdrawal?.l2_transaction?.ticket?.token?.decimals ?? 6);
+
+    const amount: string | null = await fetchWithdrawalL1ReceivedAmount(
+      networkStore.config.tezosExplorerApiUrl,
+      tx.l1TxHash,
+      tx.input?.l1_account,
+      isNativeXtz,
+      decimals
+    );
+    if (amount === null) return;
+
+    runInAction(() => {
+      if (this.selectedTransaction?.input.id !== tx.input.id) return; // user navigated away
+      this.recoveredL1Amount = amount;
+    });
+  }
+
   clearSelectedTransaction() {
     this.selectedTransaction = null;
     this.loadingState = 'idle';
     this.error = null;
+    this.recoveredL1Amount = null;
   }
 }
 

--- a/src/utils/tzktVerification.ts
+++ b/src/utils/tzktVerification.ts
@@ -1,0 +1,77 @@
+import { fetchJson } from './fetchJson';
+import { toDecimalValue } from './formatters';
+
+interface TzktTransaction {
+  id: number;
+  amount: number; // mutez
+  target?: { address: string };
+}
+
+interface TzktTokenTransfer {
+  amount: string; // raw token units
+  to?: { address: string };
+}
+
+const sameAccount = (a: string | undefined, b: string | undefined): boolean =>
+  !!a && !!b && a.toLowerCase() === b.toLowerCase();
+
+/**
+ * Sources how much a withdrawal actually delivered on Tezos (L1) from TzKT, a
+ * canonical indexer independent of our custom GraphQL indexer. Used as a
+ * fallback when the indexer doesn't return `withdrawal.l1_transaction.amount`.
+ *
+ * A withdrawal settles on L1 as an outbox execution with several internal
+ * transactions. We read the payout to the withdrawer (`l1Account`), ignoring
+ * unrelated transfers in the operation (e.g. a fixed relayer fee to another
+ * address) by matching on the account.
+ *
+ * The payout kind is decided by the token, NOT by "whichever transfer is found
+ * first": native XTZ delivers a mutez transfer, FA tokens deliver a token
+ * transfer. Branching on `isNativeXtz` avoids ever returning incidental native
+ * XTZ (e.g. dust/refund) sent to an FA-token withdrawer.
+ *
+ * Returns the received amount as a decimal string (using `decimals`), or null
+ * if it can't be determined (not found, or the request failed).
+ */
+export async function fetchWithdrawalL1ReceivedAmount(
+  tezosExplorerApiUrl: string,
+  operationHash: string,
+  l1Account: string | undefined,
+  isNativeXtz: boolean,
+  decimals: number
+): Promise<string | null> {
+  if (!operationHash || !l1Account) return null;
+
+  try {
+    const hash: string = encodeURIComponent(operationHash);
+    const transactions: TzktTransaction[] = await fetchJson<TzktTransaction[]>(
+      `${tezosExplorerApiUrl}/v1/operations/transactions/${hash}`,
+      { method: 'GET', headers: { Accept: 'application/json' } },
+      3
+    );
+
+    if (isNativeXtz) {
+      // Native XTZ payout: a positive-mutez transfer to the withdrawer.
+      const payout: TzktTransaction | undefined = transactions.find(
+        tx => tx.amount > 0 && sameAccount(tx.target?.address, l1Account)
+      );
+      return payout ? toDecimalValue(String(payout.amount), decimals).toString() : null;
+    }
+
+    // FA token payout: a token transfer to the withdrawer within this operation.
+    const ids: string = transactions.map(tx => tx.id).join(',');
+    if (!ids) return null;
+
+    const transfers: TzktTokenTransfer[] = await fetchJson<TzktTokenTransfer[]>(
+      `${tezosExplorerApiUrl}/v1/tokens/transfers?transactionId.in=${ids}`,
+      { method: 'GET', headers: { Accept: 'application/json' } },
+      3
+    );
+    const tokenPayout: TzktTokenTransfer | undefined = transfers.find(
+      tr => sameAccount(tr.to?.address, l1Account)
+    );
+    return tokenPayout ? toDecimalValue(tokenPayout.amount, decimals).toString() : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## What

A **recover plan** for when the indexer doesn't return a regular withdrawal's L1 (Tezos) amount (`withdrawal.l1_transaction.amount` null even after FINISHED): source it from **TzKT** instead, so the transaction details page still shows the received amount.

Only kicks in when the indexer amount is **missing/zero** — a healthy indexer is never second-guessed, and there's no extra UI.

## Covers both token kinds

Matched by the withdrawer's `l1_account` so unrelated transfers in the operation (e.g. a fixed relayer fee to another address) are ignored:

- **Native XTZ** — payout is a native (mutez) transfer to the withdrawer.
- **FA tokens** (stXTZ, USDtz, …) — payout is a token transfer to the withdrawer (read via TzKT's token-transfers endpoint).

**Fast withdrawals** are excluded — they already carry their L1 amount on a separately-linked payout record.

## Files

- `utils/tzktVerification.ts` (new) — `fetchWithdrawalL1ReceivedAmount`: native transfer to the account, else the token transfer to the account
- `stores/transactionDetailsStore.ts` — `recoverMissingL1Amount` fallback + `recoveredL1Amount`
- `stores/networkStore.ts` — TzKT API URLs (mainnet + shadownet)

## Testing

Verified through the running app against the two real examples from the report (indexer is healthy now, so the indexer L1 amount was forced to null to exercise the fallback):

| Token | bridge_operation.id | Recovered from TzKT |
|---|---|---|
| XTZ | 0a94a219… | 77 XTZ |
| stXTZ (FA) | d760966e… | 43172 stXTZ |

tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)