### PR TITLE
feat: Tezos X Previewnet support + Michelson L2 linking

### DIFF
--- a/src/components/TransactionDetails/DetailField.tsx
+++ b/src/components/TransactionDetails/DetailField.tsx
@@ -7,7 +7,7 @@ import { CopyButton } from '../shared/CopyButton';
 import { StatusChip } from '../shared/StatusChip';
 import { EllipsisBox } from '../shared/EllipsisBox';
 import { networkStore } from '@/stores/networkStore';
-import { getExplorerInfo } from '@/utils/explorerInfo';
+import { getExplorerInfo, ExplorerInfo } from '@/utils/explorerInfo';
 
 export type DetailFieldLabel =
   | 'Error' | 'Transaction Hash' | 'Address' | 'Block' | 'Amount'
@@ -23,15 +23,19 @@ const EXPLORER_LABELS: ReadonlySet<DetailFieldLabel> = new Set(['Transaction Has
 interface DetailFieldProps {
   label: DetailFieldLabel;
   value: string | undefined;
+  // When set, link here instead of routing by value shape (e.g. Michelson hashes
+  // whose shape would otherwise resolve to the wrong explorer).
+  explorerOverride?: ExplorerInfo;
 }
 
-export const DetailField = observer(({ label, value }: DetailFieldProps) => {
+export const DetailField = observer(({ label, value, explorerOverride }: DetailFieldProps) => {
   const theme = useTheme();
   const isCopyableAndMonospace: boolean = COPYABLE_AND_MONOSPACE_LABELS.has(label);
   const bold: boolean = BOLD_LABELS.has(label);
   const hasExplorer: boolean = EXPLORER_LABELS.has(label);
-  const explorerInfo: { url: string; name: string } | null = 
-  (value && value !== '-' && hasExplorer) ? getExplorerInfo(value, networkStore.config) : null;
+  const explorerInfo: ExplorerInfo | null =
+    explorerOverride ??
+    ((value && value !== '-' && hasExplorer) ? getExplorerInfo(value, networkStore.config) : null);
 
   return (
     <Box sx={{ mb: theme.spacing(1.5) }}>

--- a/src/components/TransactionDetails/NetworkSection.tsx
+++ b/src/components/TransactionDetails/NetworkSection.tsx
@@ -3,6 +3,7 @@
 import { observer } from 'mobx-react-lite';
 import { DataSection } from './DataSection';
 import { DetailField } from './DetailField';
+import { ExplorerInfo } from '@/utils/explorerInfo';
 
 interface NetworkSectionProps {
   title: string;
@@ -11,6 +12,8 @@ interface NetworkSectionProps {
   amount: string;
   block: string | undefined;
   showDivider?: boolean;
+  hashExplorer?: ExplorerInfo;
+  addressExplorer?: ExplorerInfo;
 }
 
 export const NetworkSection = observer(({
@@ -20,11 +23,13 @@ export const NetworkSection = observer(({
   amount,
   showDivider,
   block,
+  hashExplorer,
+  addressExplorer,
 }: NetworkSectionProps) => {
   return (
     <DataSection title={title} showDivider={showDivider}>
-      <DetailField label="Transaction Hash" value={hash} />
-      <DetailField label="Address" value={address} />
+      <DetailField label="Transaction Hash" value={hash} explorerOverride={hashExplorer} />
+      <DetailField label="Address" value={address} explorerOverride={addressExplorer} />
       <DetailField label="Block" value={block} />
       <DetailField label="Amount" value={amount} />
     </DataSection>

--- a/src/components/TransactionDetails/TransactionDetails.tsx
+++ b/src/components/TransactionDetails/TransactionDetails.tsx
@@ -65,6 +65,8 @@ export const TransactionDetails = observer(() => {
             address={transactionDetails.source.address}
             amount={`${transactionDetails.source.amount || '0'} ${transactionDetails.symbol}`}
             block={transactionDetails.source.block}
+            hashExplorer={transactionDetails.source.hashExplorer}
+            addressExplorer={transactionDetails.source.addressExplorer}
           />
 
           <NetworkSection
@@ -73,6 +75,8 @@ export const TransactionDetails = observer(() => {
             address={transactionDetails.destination.address}
             amount={`${transactionDetails.destination.amount || '0'} ${transactionDetails.symbol}`}
             block={transactionDetails.destination.block}
+            hashExplorer={transactionDetails.destination.hashExplorer}
+            addressExplorer={transactionDetails.destination.addressExplorer}
             showDivider
           />
 

--- a/src/components/TransactionDetails/TransactionDetails.tsx
+++ b/src/components/TransactionDetails/TransactionDetails.tsx
@@ -1,15 +1,17 @@
 'use client';
 
-import { 
-  Box, 
-  Typography, 
+import {
+  Box,
+  Typography,
   Card,
   CardContent,
   CircularProgress,
-  Divider
+  Divider,
+  Button
 } from '@mui/material';
 import { observer } from 'mobx-react-lite';
 import { transactionDetailsStore } from '@/stores/transactionDetailsStore';
+import { networkStore } from '@/stores/networkStore';
 import { DetailField } from './DetailField';
 import { DataSection } from './DataSection';
 import { NetworkSection } from './NetworkSection';
@@ -32,10 +34,16 @@ export const TransactionDetails = observer(() => {
   }
 
   if (hasError) {
+    const foundOn = transactionDetailsStore.foundOnNetwork;
     return (
-      <Typography color="error" sx={{ py: 4 }}>
-        {error}
-      </Typography>
+      <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', gap: 2, py: 4 }}>
+        <Typography color="error">{error}</Typography>
+        {foundOn && (
+          <Button variant="outlined" onClick={() => transactionDetailsStore.switchToFoundNetwork()}>
+            Transaction found on {networkStore.getConfig(foundOn).networkName} — switch network
+          </Button>
+        )}
+      </Box>
     );
   }
 

--- a/src/components/shared/NetworkSelector.tsx
+++ b/src/components/shared/NetworkSelector.tsx
@@ -95,6 +95,7 @@ export const NetworkSelector = observer(() => {
           >
             <MenuItem value="mainnet">Mainnet</MenuItem>
             <MenuItem value="testnet">Shadownet Testnet</MenuItem>
+            <MenuItem value="previewnet">Tezos X Previewnet</MenuItem>
           </Select>
       </FormControl>
     </Box>

--- a/src/stores/networkStore.ts
+++ b/src/stores/networkStore.ts
@@ -16,6 +16,7 @@ export interface NetworkConfig {
   // Dual-runtime networks (previewnet) have a separate Michelson L2 interface.
   michelsonExplorerUrl?: string; // Michelson L2 explorer (TzKT); API base derived as api.<host>
   gatewayContract?: string;      // Michelson L2 bridge gateway (call_evm) for exit-op lookup
+  l2Name?: string;               // L2 display name (default 'Etherlink'; previewnet is 'Tezos X')
 }
 
 const CONFIGS: Record<NetworkType, NetworkConfig> = {
@@ -49,6 +50,7 @@ const CONFIGS: Record<NetworkType, NetworkConfig> = {
     indexerKind: 'dipdup',
     michelsonExplorerUrl: 'https://previewnet.tezosx.tzkt.io',
     gatewayContract: 'KT18oDJJKXMKhfE1bSuAPGp92pYcwVDiqsPw',
+    l2Name: 'Tezos X',
   },
 };
 

--- a/src/stores/networkStore.ts
+++ b/src/stores/networkStore.ts
@@ -13,6 +13,9 @@ export interface NetworkConfig {
   // Bridge indexer schema. 'etherlink' (default) exposes l2_account as a scalar;
   // 'dipdup' (previewnet) exposes it as a relation with the scalar at l2_account_id.
   indexerKind?: 'etherlink' | 'dipdup';
+  // Dual-runtime networks (previewnet) have a separate Michelson L2 interface.
+  michelsonExplorerUrl?: string; // Michelson L2 explorer (TzKT); API base derived as api.<host>
+  gatewayContract?: string;      // Michelson L2 bridge gateway (call_evm) for exit-op lookup
 }
 
 const CONFIGS: Record<NetworkType, NetworkConfig> = {
@@ -44,8 +47,8 @@ const CONFIGS: Record<NetworkType, NetworkConfig> = {
     tezosExplorerApiUrl: 'https://api.shadownet.tzkt.io',
     graphqlEndpoint: 'https://tezosx-bridge-shadownet.dipdup.net/v1/graphql',
     indexerKind: 'dipdup',
-    // ponytail: phase 1 — EVM ops only. Michelson ops appear but link to the EVM
-    // explorer until phase-2 linking lands (michelsonExplorerUrl + TzKT op matching).
+    michelsonExplorerUrl: 'https://previewnet.tezosx.tzkt.io',
+    gatewayContract: 'KT18oDJJKXMKhfE1bSuAPGp92pYcwVDiqsPw',
   },
 };
 

--- a/src/stores/networkStore.ts
+++ b/src/stores/networkStore.ts
@@ -70,6 +70,12 @@ export class NetworkStore {
     return CONFIGS[this._currentNetwork];
   }
 
+  get networks(): NetworkType[] {
+    return Object.keys(CONFIGS) as NetworkType[];
+  }
+
+  getConfig = (network: NetworkType): NetworkConfig => CONFIGS[network];
+
   get isInitialized(): boolean {
     return this._isInitialized;
   }

--- a/src/stores/networkStore.ts
+++ b/src/stores/networkStore.ts
@@ -1,6 +1,6 @@
 import { makeAutoObservable, runInAction } from 'mobx';
 
-export type NetworkType = 'mainnet' | 'testnet';
+export type NetworkType = 'mainnet' | 'testnet' | 'previewnet';
 
 export interface NetworkConfig {
   chainId: number;
@@ -10,26 +10,43 @@ export interface NetworkConfig {
   tezosExplorerUrl: string;
   tezosExplorerApiUrl: string;
   graphqlEndpoint: string;
+  // Bridge indexer schema. 'etherlink' (default) exposes l2_account as a scalar;
+  // 'dipdup' (previewnet) exposes it as a relation with the scalar at l2_account_id.
+  indexerKind?: 'etherlink' | 'dipdup';
 }
 
-const MAINNET_CONFIG: NetworkConfig = {
-  chainId: 42793,
-  rpcUrl: 'https://node.mainnet.etherlink.com',
-  networkName: 'Etherlink Mainnet',
-  etherlinkExplorerUrl: 'https://explorer.etherlink.com',
-  tezosExplorerUrl: 'https://tzkt.io',
-  tezosExplorerApiUrl: 'https://api.tzkt.io',
-  graphqlEndpoint: 'https://bridge.indexer.etherlink.com/v1/graphql',
-};
-
-const TESTNET_CONFIG: NetworkConfig = {
-  chainId: 127823,
-  rpcUrl: 'https://node.shadownet.etherlink.com',
-  networkName: 'Etherlink Shadownet Testnet',
-  etherlinkExplorerUrl: 'https://shadownet.explorer.etherlink.com',
-  tezosExplorerUrl: 'https://shadownet.tzkt.io',
-  tezosExplorerApiUrl: 'https://api.shadownet.tzkt.io',
-  graphqlEndpoint: 'https://shadownet.bridge.indexer.etherlink.com/v1/graphql',
+const CONFIGS: Record<NetworkType, NetworkConfig> = {
+  mainnet: {
+    chainId: 42793,
+    rpcUrl: 'https://node.mainnet.etherlink.com',
+    networkName: 'Etherlink Mainnet',
+    etherlinkExplorerUrl: 'https://explorer.etherlink.com',
+    tezosExplorerUrl: 'https://tzkt.io',
+    tezosExplorerApiUrl: 'https://api.tzkt.io',
+    graphqlEndpoint: 'https://bridge.indexer.etherlink.com/v1/graphql',
+  },
+  testnet: {
+    chainId: 127823,
+    rpcUrl: 'https://node.shadownet.etherlink.com',
+    networkName: 'Etherlink Shadownet Testnet',
+    etherlinkExplorerUrl: 'https://shadownet.explorer.etherlink.com',
+    tezosExplorerUrl: 'https://shadownet.tzkt.io',
+    tezosExplorerApiUrl: 'https://api.shadownet.tzkt.io',
+    graphqlEndpoint: 'https://shadownet.bridge.indexer.etherlink.com/v1/graphql',
+  },
+  previewnet: {
+    chainId: 128064,
+    rpcUrl: 'https://evm.previewnet.tezosx.nomadic-labs.com',
+    networkName: 'Tezos X Previewnet',
+    etherlinkExplorerUrl: 'https://blockscout.previewnet.tezosx.nomadic-labs.com',
+    // Previewnet bridges to Shadownet L1, so L1 ops resolve on Shadownet's TzKT.
+    tezosExplorerUrl: 'https://shadownet.tzkt.io',
+    tezosExplorerApiUrl: 'https://api.shadownet.tzkt.io',
+    graphqlEndpoint: 'https://tezosx-bridge-shadownet.dipdup.net/v1/graphql',
+    indexerKind: 'dipdup',
+    // ponytail: phase 1 — EVM ops only. Michelson ops appear but link to the EVM
+    // explorer until phase-2 linking lands (michelsonExplorerUrl + TzKT op matching).
+  },
 };
 
 const STORAGE_KEY: string = 'tezos-etherlink-selected-network';
@@ -47,7 +64,7 @@ export class NetworkStore {
   }
 
   get config(): NetworkConfig {
-    return this._currentNetwork === 'mainnet' ? MAINNET_CONFIG : TESTNET_CONFIG;
+    return CONFIGS[this._currentNetwork];
   }
 
   get isInitialized(): boolean {
@@ -71,9 +88,9 @@ export class NetworkStore {
     
     try {
       const stored: string | null = localStorage.getItem(STORAGE_KEY);
-      if (stored === 'mainnet' || stored === 'testnet') {
+      if (stored !== null && stored in CONFIGS) {
         runInAction(() => {
-          this._currentNetwork = stored;
+          this._currentNetwork = stored as NetworkType;
         });
       }
     } catch (error) {

--- a/src/stores/tezosTransactionStore.ts
+++ b/src/stores/tezosTransactionStore.ts
@@ -189,7 +189,7 @@ export class TezosTransactionStore {
     const l2AccountField: string = isDipdup ? 'l2_account_id' : 'l2_account';
     // dipdup-only fields used to tell EVM from Michelson and pick the right address.
     const runtimeFields: string = isDipdup
-      ? 'runtime_kind\n          l2_account_meta: l2_account { origin kind home_runtime }'
+      ? 'l2_account_meta: l2_account { origin kind home_runtime }'
       : '';
 
     const andConditions: string[] = [];

--- a/src/stores/tezosTransactionStore.ts
+++ b/src/stores/tezosTransactionStore.ts
@@ -181,6 +181,10 @@ export class TezosTransactionStore {
       isFastWithdrawal
     } = filters;
 
+    // DipDup indexer (previewnet) exposes the L2 account scalar at l2_account_id;
+    // alias it back to l2_account so the response shape stays identical.
+    const l2AccountField: string = networkStore.config.indexerKind === 'dipdup' ? 'l2_account_id' : 'l2_account';
+
     const andConditions: string[] = [];
 
     if (txHash) {
@@ -210,7 +214,7 @@ export class TezosTransactionStore {
       andConditions.push(`
         _or: [
           {l1_account: {_eq: "${normalizedAddress}"}},
-          {l2_account: {_eq: "${addressWithout0x}"}}
+          {${l2AccountField}: {_eq: "${addressWithout0x}"}}
         ]
       `);
     } else if (level) {
@@ -264,7 +268,7 @@ export class TezosTransactionStore {
           created_at
           updated_at
           l1_account
-          l2_account
+          l2_account: ${l2AccountField}
           status
           is_successful
           is_completed

--- a/src/stores/tezosTransactionStore.ts
+++ b/src/stores/tezosTransactionStore.ts
@@ -2,7 +2,7 @@ import { makeAutoObservable, observable, action, reaction, runInAction } from "m
 import { toDecimalValue } from "@/utils/formatters";
 import { fetchJson } from "@/utils/fetchJson";
 import { filterStore } from "./filterStore";
-import { networkStore } from "./networkStore";
+import { networkStore, NetworkConfig } from "./networkStore";
 import { QueryFilters } from "@/types/queryFilters";
 import { 
   GraphQLResponse, 
@@ -170,7 +170,7 @@ export class TezosTransactionStore {
     this.setError(`${context}: ${errorMessage}`);
   };
 
-  private buildGraphQLQuery = (filters: QueryFilters = {}): string => {
+  private buildGraphQLQuery = (filters: QueryFilters = {}, config: NetworkConfig = networkStore.config): string => {
     const {
       limit = this.pageSize,
       offset = 0,
@@ -185,7 +185,7 @@ export class TezosTransactionStore {
 
     // DipDup indexer (previewnet) exposes the L2 account scalar at l2_account_id;
     // alias it back to l2_account so the response shape stays identical.
-    const isDipdup: boolean = networkStore.config.indexerKind === 'dipdup';
+    const isDipdup: boolean = config.indexerKind === 'dipdup';
     const l2AccountField: string = isDipdup ? 'l2_account_id' : 'l2_account';
     // dipdup-only fields used to tell EVM from Michelson and pick the right address.
     const runtimeFields: string = isDipdup
@@ -376,13 +376,13 @@ export class TezosTransactionStore {
     this.setPage(page);
   };
 
-  fetchBridgeOperations = async (filters: QueryFilters = {}): Promise<GraphQLResponse[]> => {
-    const query: string = this.buildGraphQLQuery(filters);
+  fetchBridgeOperations = async (filters: QueryFilters = {}, config: NetworkConfig = networkStore.config): Promise<GraphQLResponse[]> => {
+    const query: string = this.buildGraphQLQuery(filters, config);
 
-    const response: { 
+    const response: {
       data: { bridge_operation: GraphQLResponse[] };
       errors?: Array<{ message: string }>;
-    } = await fetchJson(networkStore.config.graphqlEndpoint, {
+    } = await fetchJson(config.graphqlEndpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ query })

--- a/src/stores/tezosTransactionStore.ts
+++ b/src/stores/tezosTransactionStore.ts
@@ -30,6 +30,7 @@ implements TransactionProps<Input>
   error: string | null = null;
   l1TxHash: string;
   l2TxHash: string;
+  l2Runtime?: 'evm' | 'michelson';
   kind: TezosTransactionKind;
   confirmation: Confirmation | undefined = undefined;
   completed = false;
@@ -47,6 +48,7 @@ implements TransactionProps<Input>
     this.chainId = props.chainId;
     this.l1TxHash = props.l1TxHash;
     this.l2TxHash = props.l2TxHash;
+    this.l2Runtime = props.l2Runtime;
     this.expectedDate = props.expectedDate;
     this.submittedDate = props.submittedDate;
     this.completedDate = props.completedDate;
@@ -183,7 +185,12 @@ export class TezosTransactionStore {
 
     // DipDup indexer (previewnet) exposes the L2 account scalar at l2_account_id;
     // alias it back to l2_account so the response shape stays identical.
-    const l2AccountField: string = networkStore.config.indexerKind === 'dipdup' ? 'l2_account_id' : 'l2_account';
+    const isDipdup: boolean = networkStore.config.indexerKind === 'dipdup';
+    const l2AccountField: string = isDipdup ? 'l2_account_id' : 'l2_account';
+    // dipdup-only fields used to tell EVM from Michelson and pick the right address.
+    const runtimeFields: string = isDipdup
+      ? 'runtime_kind\n          l2_account_meta: l2_account { origin kind home_runtime }'
+      : '';
 
     const andConditions: string[] = [];
 
@@ -200,10 +207,14 @@ export class TezosTransactionStore {
           ]
         `);
       } else {
+        // A Tezos-format hash can be an L1 op or, on Michelson L2, an L2 op hash
+        // (native Michelson deposits carry a base58 tx hash), so match both sides.
         andConditions.push(`
           _or: [
             {deposit: {l1_transaction: {operation_hash: {_eq: "${txHash}"}}}},
-            {withdrawal: {l1_transaction: {operation_hash: {_eq: "${txHash}"}}}}
+            {withdrawal: {l1_transaction: {operation_hash: {_eq: "${txHash}"}}}},
+            {deposit: {l2_transaction: {transaction_hash: {_eq: "${txHash}"}}}},
+            {withdrawal: {l2_transaction: {transaction_hash: {_eq: "${txHash}"}}}}
           ]
         `);
       }
@@ -269,6 +280,7 @@ export class TezosTransactionStore {
           updated_at
           l1_account
           l2_account: ${l2AccountField}
+          ${runtimeFields}
           status
           is_successful
           is_completed
@@ -532,7 +544,22 @@ export class TezosTransactionStore {
     const l2AmountRaw: string = txData?.l2_transaction?.amount || '0';
     const l1Hash: string = txData?.l1_transaction?.operation_hash || '';
     const l2HashRaw: string = txData?.l2_transaction?.transaction_hash || '';
-    const l2Hash: string = l2HashRaw && !l2HashRaw.startsWith('0x') ? `0x${l2HashRaw}` : l2HashRaw;
+
+    // Runtime (dipdup/previewnet only). Withdrawals always run on EVM even when
+    // michelson-originated (NAC), so they're identified by the L2 account being a
+    // michelson alias; deposits go straight to a runtime, so home_runtime is the
+    // destination (runtime_kind is unreliable for deposits: often null/wrong).
+    const meta: GraphQLResponse['l2_account_meta'] = data.l2_account_meta;
+    const l2Runtime: 'evm' | 'michelson' | undefined = meta
+      ? (data.type === 'withdrawal'
+          ? (meta.kind === 'alias' && meta.home_runtime === 'michelson' ? 'michelson' : 'evm')
+          : (meta.home_runtime ?? undefined))
+      : undefined;
+
+    // Michelson L2 hashes are Tezos op hashes (base58, no 0x); only EVM hashes get 0x.
+    const l2Hash: string = l2Runtime === 'michelson'
+      ? l2HashRaw
+      : (l2HashRaw && !l2HashRaw.startsWith('0x') ? `0x${l2HashRaw}` : l2HashRaw);
     
     const tokenMetadata = isDeposit 
       ? (txData as GraphQLResponse['deposit'])?.l1_transaction?.ticket?.token
@@ -584,6 +611,7 @@ export class TezosTransactionStore {
       completedDate: completedDate,
       l1TxHash: l1Hash,
       l2TxHash: l2Hash,
+      l2Runtime: l2Runtime,
       status: data.status,
       completed: data.is_completed,
       l1Block: l1Block,

--- a/src/stores/transactionDetailsStore.ts
+++ b/src/stores/transactionDetailsStore.ts
@@ -3,7 +3,8 @@ import { TezosTransaction, tezosTransactionStore } from "./tezosTransactionStore
 import { networkStore } from "./networkStore";
 import { GraphQLResponse } from "@/types/tezosTransaction";
 import { formatDateTime, formatEtherlinkValue } from '@/utils/formatters';
-import { fetchWithdrawalL1ReceivedAmount } from '@/utils/tzktVerification';
+import { fetchWithdrawalL1ReceivedAmount, fetchMichelsonExitOpHash } from '@/utils/tzktVerification';
+import { ExplorerInfo } from '@/utils/explorerInfo';
 
 export class TransactionDetailsStore {
   selectedTransaction: TezosTransaction | null = null;
@@ -12,6 +13,10 @@ export class TransactionDetailsStore {
 
   // L1 amount sourced from TzKT when the indexer didn't return one (see recoverMissingL1Amount)
   recoveredL1Amount: string | null = null;
+
+  // Michelson L2 op hash for a michelson-alias withdrawal, sourced from TzKT
+  // (see recoverMichelsonExitOp). The indexer only has the EVM-side hash.
+  michelsonExitOpHash: string | null = null;
 
   constructor() {
     makeAutoObservable(this);
@@ -77,15 +82,45 @@ export class TransactionDetailsStore {
       hash: formatValue(tx.l1TxHash, false),
       address: formatValue(tx.input?.l1_account, false),
       block: toBlockString(tx.l1Block),
-      amount: l1Amount
+      amount: l1Amount,
+      hashExplorer: undefined as ExplorerInfo | undefined,
+      addressExplorer: undefined as ExplorerInfo | undefined,
     };
 
+    // Dual-runtime (previewnet) L2 side: label the runtime, show the
+    // runtime-correct address, and link Michelson hashes/addresses to the
+    // Michelson explorer (shape-based routing would send them to L1 TzKT).
+    const runtime: 'evm' | 'michelson' | undefined = tx.l2Runtime;
+    const isMichelson: boolean = runtime === 'michelson';
+    const meta = tx.input?.l2_account_meta;
+    const michelsonExplorer: string | undefined = networkStore.config.michelsonExplorerUrl;
+
+    const l2Address: string | undefined = isMichelson
+      ? (meta?.origin ?? tx.input?.l2_account)        // the tz1 (alias scalar is the EVM hex)
+      : formatValue(tx.input?.l2_account, true);      // 0x + hex
+
+    const l2Hash: string | undefined = isMichelson
+      ? (tx.l2TxHash || undefined)                    // Tezos op hash, unprefixed
+      : formatValue(tx.l2TxHash, true);
+
+    // Michelson hash link: deposits carry the Tezos op hash directly; alias
+    // withdrawals run on EVM, so the op is resolved from TzKT (michelsonExitOpHash).
+    const michelsonOpHash: string | undefined = isMichelson
+      ? (isDeposit ? tx.l2TxHash : (this.michelsonExitOpHash ?? undefined))
+      : undefined;
+    const toMichelsonLink = (id: string | undefined): ExplorerInfo | undefined =>
+      isMichelson && michelsonExplorer && id
+        ? { url: `${michelsonExplorer}/${id}`, name: 'TzKT Explorer' }
+        : undefined;
+
     const l2 = {
-      network: 'Etherlink',
-      hash: formatValue(tx.l2TxHash, true),
-      address: formatValue(tx.input?.l2_account, true),
+      network: runtime ? `Etherlink (${isMichelson ? 'Michelson' : 'EVM'})` : 'Etherlink',
+      hash: l2Hash,
+      address: l2Address,
       block: toBlockString(tx.l2Block),
-      amount: isDeposit ? tx.receivingAmount : tx.sendingAmount
+      amount: isDeposit ? tx.receivingAmount : tx.sendingAmount,
+      hashExplorer: toMichelsonLink(michelsonOpHash),
+      addressExplorer: toMichelsonLink(l2Address),
     };
 
     return {
@@ -131,6 +166,7 @@ export class TransactionDetailsStore {
     this.loadingState = 'loading';
     this.error = null;
     this.recoveredL1Amount = null;
+    this.michelsonExitOpHash = null;
 
     try {
       const operations: GraphQLResponse[] | null = await this.fetchOperationByHash(hash);
@@ -162,6 +198,10 @@ export class TransactionDetailsStore {
       // If the indexer didn't return an L1 amount, source it from TzKT in the
       // background so the page renders immediately and updates reactively.
       void this.recoverMissingL1Amount(transaction);
+
+      // Michelson-alias withdrawals only carry their EVM-side hash in the indexer;
+      // resolve the Michelson op from TzKT in the background for the explorer link.
+      void this.recoverMichelsonExitOp(transaction);
 
       return transaction;
 
@@ -206,11 +246,37 @@ export class TransactionDetailsStore {
     });
   }
 
+  // Resolves the Michelson L2 op hash for a michelson-alias withdrawal from TzKT.
+  // No-op for EVM ops, deposits (their L2 hash is already the Tezos op), or
+  // networks without a Michelson interface.
+  private async recoverMichelsonExitOp(tx: TezosTransaction<GraphQLResponse>): Promise<void> {
+    if (tx.l2Runtime !== 'michelson' || tx.type !== 'withdrawal') return;
+
+    const cfg = networkStore.config;
+    if (!cfg.michelsonExplorerUrl || !cfg.gatewayContract) return;
+    if (tx.l2Block == null) return;
+
+    const hash: string | null = await fetchMichelsonExitOpHash(
+      cfg.michelsonExplorerUrl,
+      cfg.gatewayContract,
+      tx.l2Block,
+      tx.input?.withdrawal?.l2_transaction?.amount,
+      tx.input?.l2_account_meta?.origin ?? tx.input?.l1_account
+    );
+    if (hash === null) return;
+
+    runInAction(() => {
+      if (this.selectedTransaction?.input.id !== tx.input.id) return; // user navigated away
+      this.michelsonExitOpHash = hash;
+    });
+  }
+
   clearSelectedTransaction() {
     this.selectedTransaction = null;
     this.loadingState = 'idle';
     this.error = null;
     this.recoveredL1Amount = null;
+    this.michelsonExitOpHash = null;
   }
 }
 

--- a/src/stores/transactionDetailsStore.ts
+++ b/src/stores/transactionDetailsStore.ts
@@ -1,6 +1,6 @@
 import { makeAutoObservable, runInAction } from "mobx";
 import { TezosTransaction, tezosTransactionStore } from "./tezosTransactionStore";
-import { networkStore } from "./networkStore";
+import { networkStore, NetworkType } from "./networkStore";
 import { GraphQLResponse } from "@/types/tezosTransaction";
 import { formatDateTime, formatEtherlinkValue } from '@/utils/formatters';
 import { fetchWithdrawalL1ReceivedAmount, fetchMichelsonExitOpHash } from '@/utils/tzktVerification';
@@ -17,6 +17,11 @@ export class TransactionDetailsStore {
   // Michelson L2 op hash for a michelson-alias withdrawal, sourced from TzKT
   // (see recoverMichelsonExitOp). The indexer only has the EVM-side hash.
   michelsonExitOpHash: string | null = null;
+
+  // Search is network-scoped. When a hash isn't on the selected network, we probe
+  // the others; if found, this names the network so the UI can offer a switch.
+  searchedHash: string | null = null;
+  foundOnNetwork: NetworkType | null = null;
 
   constructor() {
     makeAutoObservable(this);
@@ -167,11 +172,15 @@ export class TransactionDetailsStore {
     this.error = null;
     this.recoveredL1Amount = null;
     this.michelsonExitOpHash = null;
+    this.searchedHash = hash;
+    this.foundOnNetwork = null;
 
     try {
       const operations: GraphQLResponse[] | null = await this.fetchOperationByHash(hash);
       
       if (!operations || operations.length === 0) {
+        // Not on the selected network — probe the others so the UI can offer a switch.
+        await this.probeOtherNetworks(hash);
         this.handleError(new Error('Transaction not found'), 'Transaction by hash lookup');
         return null;
       }
@@ -271,12 +280,51 @@ export class TransactionDetailsStore {
     });
   }
 
+  // Probes the non-selected networks for the hash. Stops at the first hit and
+  // records it (a tx hash is unique to one chain). A bare existence query works
+  // across both indexer schemas, so no per-network field handling is needed.
+  private async probeOtherNetworks(hash: string): Promise<void> {
+    const others: NetworkType[] = networkStore.networks.filter(n => n !== networkStore.currentNetwork);
+
+    for (const network of others) {
+      try {
+        const ops = await tezosTransactionStore.fetchBridgeOperations(
+          { txHash: hash, limit: 1 },
+          networkStore.getConfig(network)
+        );
+        if (ops && ops.length > 0) {
+          runInAction(() => {
+            if (this.searchedHash !== hash) return; // a newer search superseded this one
+            this.foundOnNetwork = network;
+          });
+          return;
+        }
+      } catch {
+        // One network's indexer failing shouldn't stop us probing the rest.
+      }
+    }
+  }
+
+  // Switches to the network where the hash was found and re-runs the lookup, so
+  // the detail page renders with that network's config (explorer URLs, etc.).
+  switchToFoundNetwork = (): void => {
+    const network: NetworkType | null = this.foundOnNetwork;
+    const hash: string | null = this.searchedHash;
+    if (!network || !hash) return;
+
+    networkStore.setNetwork(network);
+    this.foundOnNetwork = null;
+    void this.getTransactionDetails(hash);
+  };
+
   clearSelectedTransaction() {
     this.selectedTransaction = null;
     this.loadingState = 'idle';
     this.error = null;
     this.recoveredL1Amount = null;
     this.michelsonExitOpHash = null;
+    this.searchedHash = null;
+    this.foundOnNetwork = null;
   }
 }
 

--- a/src/stores/transactionDetailsStore.ts
+++ b/src/stores/transactionDetailsStore.ts
@@ -99,6 +99,7 @@ export class TransactionDetailsStore {
     const isMichelson: boolean = runtime === 'michelson';
     const meta = tx.input?.l2_account_meta;
     const michelsonExplorer: string | undefined = networkStore.config.michelsonExplorerUrl;
+    const l2Name: string = networkStore.config.l2Name ?? 'Etherlink';
 
     const l2Address: string | undefined = isMichelson
       ? (meta?.origin ?? tx.input?.l2_account)        // the tz1 (alias scalar is the EVM hex)
@@ -121,7 +122,7 @@ export class TransactionDetailsStore {
         : undefined;
 
     const l2 = {
-      network: runtime ? `Etherlink (${isMichelson ? 'Michelson' : 'EVM'})` : 'Etherlink',
+      network: runtime ? `${l2Name} (${isMichelson ? 'Michelson' : 'EVM'})` : l2Name,
       hash: l2Hash,
       address: l2Address,
       block: toBlockString(tx.l2Block),
@@ -138,7 +139,7 @@ export class TransactionDetailsStore {
       source: isDeposit ? l1 : l2,
       destination: isDeposit ? l2 : l1,
       status: tx.status || 'Unknown',
-      networkFlow: `${isDeposit ? 'Tezos' : 'Etherlink'} → ${isDeposit ? 'Etherlink' : 'Tezos'}`,
+      networkFlow: `${isDeposit ? 'Tezos' : l2Name} → ${isDeposit ? l2Name : 'Tezos'}`,
       createdAt: tx.submittedDate ? formatDateTime(new Date(tx.submittedDate)) : 'Unknown',
       expectedAt: tx.expectedDate ? formatDateTime(new Date(tx.expectedDate)) : null,
       kind: tx.kind ? tx.kind.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase()) : null,

--- a/src/stores/transactionDetailsStore.ts
+++ b/src/stores/transactionDetailsStore.ts
@@ -104,15 +104,17 @@ export class TransactionDetailsStore {
       ? (meta?.origin ?? tx.input?.l2_account)        // the tz1 (alias scalar is the EVM hex)
       : formatValue(tx.input?.l2_account, true);      // 0x + hex
 
-    const l2Hash: string | undefined = isMichelson
-      ? (tx.l2TxHash || undefined)                    // Tezos op hash, unprefixed
-      : formatValue(tx.l2TxHash, true);
-
-    // Michelson hash link: deposits carry the Tezos op hash directly; alias
-    // withdrawals run on EVM, so the op is resolved from TzKT (michelsonExitOpHash).
+    // Michelson hash: deposits carry the Tezos op hash directly; alias withdrawals
+    // run on EVM, so the op is resolved from TzKT (michelsonExitOpHash).
     const michelsonOpHash: string | undefined = isMichelson
       ? (isDeposit ? tx.l2TxHash : (this.michelsonExitOpHash ?? undefined))
       : undefined;
+
+    // Display the resolved Michelson op hash so the shown value matches the link;
+    // until an alias withdrawal's op resolves, fall back to the EVM hash we have.
+    const l2Hash: string | undefined = isMichelson
+      ? (michelsonOpHash ?? tx.l2TxHash ?? undefined)
+      : formatValue(tx.l2TxHash, true);
     const toMichelsonLink = (id: string | undefined): ExplorerInfo | undefined =>
       isMichelson && michelsonExplorer && id
         ? { url: `${michelsonExplorer}/${id}`, name: 'TzKT Explorer' }

--- a/src/types/tezosTransaction.ts
+++ b/src/types/tezosTransaction.ts
@@ -24,6 +24,14 @@ export interface GraphQLResponse {
   updated_at: string;
   l1_account: string;
   l2_account: string;
+  // dipdup-only (previewnet): which L2 runtime an op ran on, and the L2 account
+  // metadata used to derive origin + the runtime-correct address.
+  runtime_kind?: 'evm' | 'michelson' | null;
+  l2_account_meta?: {
+    origin: string;
+    kind: 'unknown' | 'native' | 'alias';
+    home_runtime: 'evm' | 'michelson' | null;
+  };
   status: GraphTokenStatus;
   is_successful: boolean;
   is_completed: boolean;
@@ -110,6 +118,7 @@ export interface TransactionProps<Input> {
   error: string | null;
   l1TxHash: string;
   l2TxHash: string;
+  l2Runtime?: 'evm' | 'michelson';
   kind: TezosTransactionKind | null;
   confirmation: Confirmation | undefined;
   completed: boolean;

--- a/src/types/tezosTransaction.ts
+++ b/src/types/tezosTransaction.ts
@@ -24,9 +24,8 @@ export interface GraphQLResponse {
   updated_at: string;
   l1_account: string;
   l2_account: string;
-  // dipdup-only (previewnet): which L2 runtime an op ran on, and the L2 account
-  // metadata used to derive origin + the runtime-correct address.
-  runtime_kind?: 'evm' | 'michelson' | null;
+  // dipdup-only (previewnet): L2 account metadata used to derive the runtime
+  // (origin) + the runtime-correct address.
   l2_account_meta?: {
     origin: string;
     kind: 'unknown' | 'native' | 'alias';

--- a/src/utils/tzktVerification.ts
+++ b/src/utils/tzktVerification.ts
@@ -53,6 +53,10 @@ export async function fetchMichelsonExitOpHash(
     if (!ops || ops.length === 0) return null;
     if (ops.length === 1) return ops[0].hash;
 
+    // ponytail: amount tiebreak assumes native XTZ (wei 18dp -> mutez 6dp). For FA
+    // tokens this won't match and we fall back to ops[0]; acceptable because the
+    // level (+sender) filter almost always yields a single op. Pass token decimals
+    // here if same-level FA collisions ever surface.
     const mutez: string | undefined = amountWei
       ? (BigInt(amountWei) / BigInt('1000000000000')).toString()
       : undefined;

--- a/src/utils/tzktVerification.ts
+++ b/src/utils/tzktVerification.ts
@@ -15,6 +15,53 @@ interface TzktTokenTransfer {
 const sameAccount = (a: string | undefined, b: string | undefined): boolean =>
   !!a && !!b && a.toLowerCase() === b.toLowerCase();
 
+interface TzktCallEvmOp {
+  hash: string;
+  amount: number; // mutez
+}
+
+/**
+ * Resolves the Michelson L2 op hash for a michelson-alias withdrawal. The bridge
+ * indexer only carries the EVM-side hash for these (the withdrawal runs on EVM via
+ * NAC), so the real Tezos op is found on the Michelson L2's TzKT: the gateway's
+ * `call_evm` op at the withdrawal's L2 level. When several ops share a level we
+ * disambiguate by amount (indexer wei = tzkt mutez * 1e12 for native XTZ).
+ *
+ * Returns the op hash, or null if none matches / the request failed.
+ */
+export async function fetchMichelsonExitOpHash(
+  michelsonExplorerUrl: string,
+  gatewayContract: string,
+  level: number,
+  amountWei: string | undefined,
+  sender: string | undefined
+): Promise<string | null> {
+  if (!level || !gatewayContract) return null;
+
+  // The Michelson explorer's TzKT API lives at the api.<host> subdomain.
+  const apiBase: string = michelsonExplorerUrl.replace('://', '://api.');
+  const senderParam: string = sender ? `&sender=${sender}` : '';
+
+  try {
+    const ops: TzktCallEvmOp[] = await fetchJson<TzktCallEvmOp[]>(
+      `${apiBase}/v1/operations/transactions`
+        + `?target=${gatewayContract}&entrypoint=call_evm&level=${level}${senderParam}`
+        + `&limit=20&sort.desc=id`,
+      { method: 'GET', headers: { Accept: 'application/json' } },
+      3
+    );
+    if (!ops || ops.length === 0) return null;
+    if (ops.length === 1) return ops[0].hash;
+
+    const mutez: string | undefined = amountWei
+      ? (BigInt(amountWei) / BigInt('1000000000000')).toString()
+      : undefined;
+    return (ops.find(op => String(op.amount) === mutez) ?? ops[0]).hash;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Sources how much a withdrawal actually delivered on Tezos (L1) from TzKT, a
  * canonical indexer independent of our custom GraphQL indexer. Used as a


### PR DESCRIPTION
## Summary

Adds **Tezos X Previewnet** as a selectable network and handles its dual-runtime (EVM + Michelson) bridge operations, plus a cross-network tx-hash search.

Previewnet bridges to Shadownet L1 but has its own DipDup-hosted indexer whose schema differs from the etherlink indexer, and its bridge ops split across two L2 interfaces (EVM via Blockscout, Michelson via TzKT).

## What's included

**1. Previewnet network support** (`f74667e`)
- Network configs move from two constants + a ternary to a `Record<NetworkType, NetworkConfig>` map — future networks are a single entry.
- Previewnet entry: chainId `128064`, EVM RPC/Blockscout, shared Shadownet L1 TzKT, DipDup indexer.
- The DipDup schema exposes `l2_account` as a relation (scalar at `l2_account_id`); the query branches on a new `indexerKind` field and aliases it back so the response shape is unchanged.

**2. Michelson L2 linking + runtime display** (`ace9716`)
- Detail page labels the L2 side **Etherlink (Michelson)** / **(EVM)**.
- Shows the runtime-correct address: `tz1…` for Michelson (from `l2_account.origin`), `0x…` for EVM.
- Links Michelson hashes/addresses to the Michelson explorer. Native-Michelson deposits carry the Tezos op hash directly; alias withdrawals run on EVM, so the op is resolved from TzKT (gateway `call_evm` at the withdrawal's level, amount tiebreak) in the background.
- Stops `0x`-prefixing Michelson L2 hashes; widens the by-hash lookup to match Michelson L2 op hashes.

**3. Cross-network search** (`5b13498`)
- Tx-hash search queries the selected network first; on a miss, probes the other networks and offers a **"Transaction found on `<network>` — switch network"** button. Hash-only (addresses/blocks have separate per-chain activity).

## Verification
- `tsc` + ESLint clean.
- Live checks against the real indexers/TzKT: Michelson exit-op resolution (level 885569 → `ooVMMV9…`), Michelson deposit lookup by L2 op hash, and the search probe discriminating previewnet vs mainnet.

## Deferred (intentional)
- L1-hash backfill for `null` L1 ops on Michelson withdrawals (needs a separate Shadownet-L1 query).
- Runtime-correct address in the **table** view (only the detail page has it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)